### PR TITLE
GL/GLES fixes

### DIFF
--- a/shader/default.hps
+++ b/shader/default.hps
@@ -1,3 +1,3 @@
 {
-	"features": ["OptionalDiffuseMap", "OptionalSpecularMap", "OptionalNormalMap", "OptionalSelfMap", "OptionalSkinning"]
+	"features": ["OptionalDiffuseMap", "OptionalSkinning"]
 }

--- a/shader/font_fs.sc
+++ b/shader/font_fs.sc
@@ -7,6 +7,6 @@ uniform vec4 u_color;
 SAMPLER2D(u_tex, 0);
 
 void main() {
-	float opacity = texture2D(u_tex, v_texcoord0).a * u_color.a;
-	gl_FragColor = vec4(u_color.rgb, opacity); 
+	float opacity = texture2D(u_tex, v_texcoord0).w * u_color.w;
+	gl_FragColor = vec4(u_color.xyz, opacity); 
 }

--- a/shader/hiz_trace.sh
+++ b/shader/hiz_trace.sh
@@ -8,27 +8,27 @@ uniform vec4 u_depthTexInfos; // width(x) heigh(y) start mipmap level(z) max mip
 
 //
 vec3 ray_step_cell(vec3 ray, vec3 dir, float step, vec2 z_range) {
-	float t_ = 100000000.0; // [EJ] any large value is ok
+	float t = 100000000.0; // [EJ] any large value is ok
 
 	if (dir.x > 0.0)
-		t_ = min(t_, (floor(ray.x / step + 1.0) * step - ray.x) / dir.x);
+		t = min(t, (floor(ray.x / step + 1.0) * step - ray.x) / dir.x);
 	else if (dir.x < 0.0)
-		t_ = min(t_, (ceil(ray.x / step - 1.0) * step - ray.x) / dir.x);
+		t = min(t, (ceil(ray.x / step - 1.0) * step - ray.x) / dir.x);
 
 	if (dir.y > 0.0)
-		t_ = min(t_, (floor(ray.y / step + 1.0) * step - ray.y) / dir.y);
+		t = min(t, (floor(ray.y / step + 1.0) * step - ray.y) / dir.y);
 	else if (dir.y < 0.0)
-		t_ = min(t_, (ceil(ray.y / step - 1.0) * step - ray.y) / dir.y);
+		t = min(t, (ceil(ray.y / step - 1.0) * step - ray.y) / dir.y);
 
 	if (dir.z > 0.0) {
 		if (ray.z < z_range.x)
-			t_ = min(t_, (z_range.x - ray.z) / dir.z);
+			t = min(t, (z_range.x - ray.z) / dir.z);
 	} else if (dir.z < 0.0) {
 		if (ray.z > z_range.y)
-			t_ = min(t_, (z_range.y - ray.z) / dir.z);
+			t = min(t, (z_range.y - ray.z) / dir.z);
 	}
 
-	return ray + dir * t_;
+	return ray + dir * t;
 }
 
 float hiz_trace(vec3 ray_o, vec3 ray_d, mat4 proj, float z_near, int max_iterations, out vec3 ray) {

--- a/shader/hiz_trace.sh
+++ b/shader/hiz_trace.sh
@@ -87,8 +87,8 @@ float hiz_trace(vec3 ray_o, vec3 ray_d, mat4 proj, float z_near, int max_iterati
 		}
 	}
 
-	vec2 k_fade = saturate((ray.xy - viewport_min) / (u_viewRect.zw * 0.1));
-	k_fade *= saturate(vec2(1.0, 1.0) - (ray.xy - viewport_max * 0.9) / (u_viewRect.zw * 0.1));
+	vec2 k_fade = saturate((ray.xy - viewport_min.xy) / (u_viewRect.zw * 0.1));
+	k_fade *= saturate(vec2(1.0, 1.0) - (ray.xy - viewport_max.xy * 0.9) / (u_viewRect.zw * 0.1));
 
 	ray.xy /= u_depthTexInfos.xy;
 

--- a/shader/pbr_fs.sc
+++ b/shader/pbr_fs.sc
@@ -38,15 +38,15 @@ float SampleShadowPCF(sampler2DShadow map, vec4 coord, float inv_pixel_size, flo
 	float k = 0.0;
 
 #if FORWARD_PIPELINE_AAA
-	#define PCF_SAMPLE_COUNT 2.0 // 3x3
+	#define PCF_SAMPLE_COUNT 2 // 3x3
 
-//	float weights[9] = {0.024879, 0.107973, 0.024879, 0.107973, 0.468592, 0.107973, 0.024879, 0.107973, 0.024879};
-	float weights[9] = {0.011147, 0.083286, 0.011147, 0.083286, 0.622269, 0.083286, 0.011147, 0.083286, 0.011147};
+//	ARRAY_BEGIN(float, weights, 9) 0.024879, 0.107973, 0.024879, 0.107973, 0.468592, 0.107973, 0.024879, 0.107973, 0.024879 ARRAY_END();
+	ARRAY_BEGIN(float, weights, 9) 0.011147, 0.083286, 0.011147, 0.083286, 0.622269, 0.083286, 0.011147, 0.083286, 0.011147 ARRAY_END();
 
-	for (float j = 0.0; j <= PCF_SAMPLE_COUNT; ++j) {
-		float v = 6.0 * (j + jitter.y) / PCF_SAMPLE_COUNT - 1.0;
-		for (float i = 0.0; i <= PCF_SAMPLE_COUNT; ++i) {
-			float u = 6.0 * (i + jitter.x) / PCF_SAMPLE_COUNT - 1.0;
+	for (int j = 0; j <= PCF_SAMPLE_COUNT; ++j) {
+		float v = 6.0 * (float(j) + jitter.y) / float(PCF_SAMPLE_COUNT) - 1.0;
+		for (int i = 0; i <= PCF_SAMPLE_COUNT; ++i) {
+			float u = 6.0 * (float(i) + jitter.x) / float(PCF_SAMPLE_COUNT) - 1.0;
 			k += SampleHardShadow(map, coord + vec4(vec2(u, v) * k_pixel_size, 0.0, 0.0), bias) * weights[j * 3 + i];
 		}
 	}
@@ -247,7 +247,7 @@ void main() {
 	vec4 ss_radiance = texture2D(uSSRadianceMap, gl_FragCoord.xy / uResolution.xy);
 
 	irradiance = ss_irradiance.xyz; // mix(irradiance, ss_irradiance, ss_irradiance.w);
-	radiance = mix(radiance, ss_radiance, ss_radiance.w);
+	radiance = mix(radiance, ss_radiance.xyz, ss_radiance.w);
 #endif
 
 	vec3 diffuse = irradiance * base_opacity.xyz;

--- a/shader/ssgi_fs.sc
+++ b/shader/ssgi_fs.sc
@@ -22,11 +22,11 @@ void main() {
 	vec4 jitter = texture2D(u_noise, mod(gl_FragCoord.xy, vec2(64, 64)) / vec2(64, 64));
 
 	// sample normal/depth
-	vec2 uv = GetAttributeTexCoord(vTexCoord0, textureSize(u_attr0, 0).xy);
+	vec2 uv = GetAttributeTexCoord(vTexCoord0, vec2(textureSize(u_attr0, 0).xy));
 	vec4 attr0 = texture2D(u_attr0, uv);
 
 	vec3 n = normalize(attr0.xyz);
-	if (isNan(n.x) || isNan(n.y)  |isNan(n.z))
+	if (isNan(n.x) || isNan(n.y) || isNan(n.z))
 		n = vec3(0, 1, 0);
 
 	// compute ray origin & direction
@@ -45,7 +45,7 @@ void main() {
 		float cos_spread = cos(spread), sin_spread = sin(spread);
 
 		for (int j = 0; j < int(sample_count); ++j) {
-			float angle = float(j + jitter.w) / sample_count * 2. * 3.141592;
+			float angle = (float(j) + jitter.w) / sample_count * 2.0 * 3.141592;
 			float cos_angle = cos(angle), sin_angle = sin(angle);
 			vec3 ray_d_spread = (right * cos_angle + up * sin_angle) * sin_spread + n * cos_spread;
 

--- a/shader/ssr_fs.sc
+++ b/shader/ssr_fs.sc
@@ -97,6 +97,7 @@ void main() {
 	}
 
 	color /= sample_count * sample_count;
+	color = (saturate(color) / 32.0) * 32.0;
 #endif
 
 	gl_FragColor = color;

--- a/shader/ssr_fs.sc
+++ b/shader/ssr_fs.sc
@@ -97,7 +97,7 @@ void main() {
 	}
 
 	color /= sample_count * sample_count;
-	color = (saturate(color) / 32.0) * 32.0;
+	color = clamp(color, 0.0, 32.0); // [FG] Avoid high intensity HDR probes from saturating the SSR buffer.
 #endif
 
 	gl_FragColor = color;

--- a/shader/ssr_fs.sc
+++ b/shader/ssr_fs.sc
@@ -22,11 +22,11 @@ void main() {
 	vec4 jitter = texture2D(u_noise, mod(gl_FragCoord.xy, vec2(64, 64)) / vec2(64, 64));
 
 	// sample normal/depth
-	vec2 uv = GetAttributeTexCoord(vTexCoord0, textureSize(u_attr0, 0).xy);
+	vec2 uv = GetAttributeTexCoord(vTexCoord0, vec2(textureSize(u_attr0, 0).xy));
 	vec4 attr0 = texture2D(u_attr0, uv);
 
 	vec3 n = normalize(attr0.xyz);
-	if (isNan(n.x) || isNan(n.y)  |isNan(n.z))
+	if (isNan(n.x) || isNan(n.y) || isNan(n.z))
 		n = vec3(0, 1, 0);
 
 	// compute ray origin & direction
@@ -66,7 +66,7 @@ void main() {
 		float cos_spread = cos(spread), sin_spread = sin(spread);
 
 		for (int j = 0; j < int(sample_count); ++j) {
-			float angle = float(j + jitter.w) / sample_count * 2. * 3.141592;
+			float angle = (float(j) + jitter.w) / sample_count * 2.0 * 3.141592;
 			vec3 ray_d_spread = (right * cos(angle) + up * sin(angle)) * sin_spread + ray_d * cos_spread;
 
 			vec3 world_ray_d = mul(uMainInvView, vec4(ray_d_spread, 0.0)).xyz;
@@ -85,11 +85,11 @@ void main() {
 
 				float log_depth = ComputeRayLogDepth(uMainProjection, hit_point);
 
-				vec4 output = vec4(0.0, 0.0, 0.0, 1.0); // assume backface hit
+				vec4 ss_output = vec4(0.0, 0.0, 0.0, 1.0); // assume backface hit
 				if (dot(attr0.xyz, ray_d_spread) < 0.0 && hit_point.z <= log_depth)
-					output = vec4(texture2D(u_color, uv - vel * uv_ratio).xyz, 1.0); // front face hit
+					ss_output = vec4(texture2D(u_color, uv - vel * uv_ratio).xyz, 1.0); // front face hit
 
-				color += mix(fallback, output, k);
+				color += mix(fallback, ss_output, k);
 			} else {
 				color += fallback;
 			}

--- a/shader/temporal_accumulation_fs.sc
+++ b/shader/temporal_accumulation_fs.sc
@@ -25,7 +25,7 @@ void main() {
 	vec2 uv = gl_FragCoord.xy / input_size;
 	vec2 dt = GetVelocityVector(uv, uResolution.xy / input_size.xy);
 
-	vec2 uv_curr = GetAttributeTexCoord(vTexCoord0, textureSize(u_current, 0).xy);
+	vec2 uv_curr = GetAttributeTexCoord(vTexCoord0, vec2(textureSize(u_current, 0).xy));
 	vec4 current = texture2D(u_current, uv_curr);
 	 
     vec4 c0 = texture2DLodOffset(u_current, uv_curr, 0, ivec2(0, 1));


### PR DESCRIPTION
- Various fixes to improve the GL/GLES support of the core shaders using @scorpheus' contributions:
  - vec3.rgb replaced by vec3.xyz
  - float/int/vec explicit cast when required
  - array definition "ala BGFX"
  - fixed a typo in the ssgi/ssr shaders, on a condition testing the NaN normals
  - 'output' is a reserved keyword in OpenGL, renamed it
  - clamped the color output of the SSR to avoid NaN spreading in the framebuffer (using an arbitrary value, based on the experiment on HDR probes provided by the artists)
  - the variable `t_` fails to compile on OpenGL (the underscore prefix is rejected by the OpenGL compiler)
  - proposal to simplify the amount of variants of the `default`shader.